### PR TITLE
Polluted location creation form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "lint-staged": "^13.0.3",
         "prettier": "^2.7.1",
         "react": "^18.2.0",
+        "react-div-100vh": "^0.7.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.4.0",
         "react-scripts": "5.0.1",
@@ -14406,6 +14407,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/react-div-100vh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/react-div-100vh/-/react-div-100vh-0.7.0.tgz",
+      "integrity": "sha512-I3d77tQyaSlOx/6vurDDLk7upb5GA2ldEtVXkk7Kn5cy+tLlS0KlqDK14xUxlxh7jz4StjgKcwFyrpymsPpomA==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -27367,6 +27376,12 @@
           }
         }
       }
+    },
+    "react-div-100vh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/react-div-100vh/-/react-div-100vh-0.7.0.tgz",
+      "integrity": "sha512-I3d77tQyaSlOx/6vurDDLk7upb5GA2ldEtVXkk7Kn5cy+tLlS0KlqDK14xUxlxh7jz4StjgKcwFyrpymsPpomA==",
+      "requires": {}
     },
     "react-dom": {
       "version": "18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@tailwindcss/forms": "^0.5.3",
         "autoprefixer": "^10.4.8",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -3449,6 +3450,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.3.tgz",
+      "integrity": "sha512-y5mb86JUoiUgBjY/o6FJSFZSEttfb3Q5gllE4xoKjAAD+vBrnIhE4dViwUuow3va8mpH4s9jyUbUbrRGoRdc2Q==",
+      "dev": true,
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -12113,6 +12126,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -19573,6 +19595,15 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@tailwindcss/forms": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.3.tgz",
+      "integrity": "sha512-y5mb86JUoiUgBjY/o6FJSFZSEttfb3Q5gllE4xoKjAAD+vBrnIhE4dViwUuow3va8mpH4s9jyUbUbrRGoRdc2Q==",
+      "dev": true,
+      "requires": {
+        "mini-svg-data-uri": "^1.2.3"
+      }
+    },
     "@testing-library/dom": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.17.1.tgz",
@@ -25886,6 +25917,12 @@
           }
         }
       }
+    },
+    "mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     ]
   },
   "devDependencies": {
+    "@tailwindcss/forms": "^0.5.3",
     "autoprefixer": "^10.4.8",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
     "react": "^18.2.0",
+    "react-div-100vh": "^0.7.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",
     "react-scripts": "5.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,21 +4,16 @@ import { getAllPollutedLocations } from "./backEndClient";
 import { mapToPollutedLocation } from "./types/backEnd/PollutedLocationResponse";
 import PollutedLocation from "./types/PollutedLocation";
 import { ApiRequest } from "./types/backEnd/ApiRequest";
-import Map from "./components/map/Map";
-import SideBar, { sideBarModes } from "./components/sideBar/SideBar";
+import Map, { vilniusCoordinates } from "./components/map/Map";
+import SideBar from "./components/sideBar/SideBar";
 
 const App: React.FC = () => {
   const googleMapRef = useRef<google.maps.Map | null>(null);
 
-  const vilniusCoordinates: google.maps.LatLngLiteral = {
-    lat: 54.6872,
-    lng: 25.2797,
-  };
   const [mapCenter, setMapCenter] =
     useState<google.maps.LatLngLiteral>(vilniusCoordinates);
 
-  const [sideBarMode, setSideBarMode] =
-    useState<typeof sideBarModes[number]>("list");
+  const [showCenterMarker, setShowCenterMarker] = useState<boolean>(false);
 
   const [pollutedLocations, setPollutedLocations] = useState<
     ApiRequest<PollutedLocation[]>
@@ -47,14 +42,13 @@ const App: React.FC = () => {
         mapRef={googleMapRef}
         center={mapCenter}
         setCenter={(newCenter) => setMapCenter(newCenter)}
-        showCenterMarker={sideBarMode === "form"}
+        showCenterMarker={showCenterMarker}
       />
       <SideBar
         locationsRequest={pollutedLocations}
         googleMap={googleMapRef}
         coordinates={mapCenter}
-        currentMode={sideBarMode}
-        setCurrentMode={(newSideBarMode) => setSideBarMode(newSideBarMode)}
+        setShowCenterMarker={(newValue) => setShowCenterMarker(newValue)}
       />
     </Layout>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,16 @@ const App: React.FC = () => {
         googleMap={googleMapRef}
         coordinates={mapCenter}
         setShowCenterMarker={(newValue) => setShowCenterMarker(newValue)}
+        addCreatedPollutedLocation={(newLocation) => {
+          setPollutedLocations((prevState) => {
+            if (prevState.status !== "success") return prevState;
+
+            return {
+              ...prevState,
+              data: [...prevState.data, newLocation],
+            };
+          });
+        }}
       />
     </Layout>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,20 @@ import { mapToPollutedLocation } from "./types/backEnd/PollutedLocationResponse"
 import PollutedLocation from "./types/PollutedLocation";
 import { ApiRequest } from "./types/backEnd/ApiRequest";
 import Map from "./components/map/Map";
-import SideBar from "./components/sideBar/SideBar";
+import SideBar, { sideBarModes } from "./components/sideBar/SideBar";
 
 const App: React.FC = () => {
   const googleMapRef = useRef<google.maps.Map | null>(null);
+
+  const vilniusCoordinates: google.maps.LatLngLiteral = {
+    lat: 54.6872,
+    lng: 25.2797,
+  };
+  const [mapCenter, setMapCenter] =
+    useState<google.maps.LatLngLiteral>(vilniusCoordinates);
+
+  const [sideBarMode, setSideBarMode] =
+    useState<typeof sideBarModes[number]>("list");
 
   const [pollutedLocations, setPollutedLocations] = useState<
     ApiRequest<PollutedLocation[]>
@@ -32,8 +42,20 @@ const App: React.FC = () => {
 
   return (
     <Layout>
-      <Map locationsRequest={pollutedLocations} mapRef={googleMapRef} />
-      <SideBar locationsRequest={pollutedLocations} googleMap={googleMapRef} />
+      <Map
+        locationsRequest={pollutedLocations}
+        mapRef={googleMapRef}
+        center={mapCenter}
+        setCenter={(newCenter) => setMapCenter(newCenter)}
+        showCenterMarker={sideBarMode === "form"}
+      />
+      <SideBar
+        locationsRequest={pollutedLocations}
+        googleMap={googleMapRef}
+        coordinates={mapCenter}
+        currentMode={sideBarMode}
+        setCurrentMode={(newSideBarMode) => setSideBarMode(newSideBarMode)}
+      />
     </Layout>
   );
 };

--- a/src/backEndClient.ts
+++ b/src/backEndClient.ts
@@ -1,8 +1,20 @@
 import axios from "axios";
+import PollutedLocationCreateRequest from "./types/backEnd/PollutedLocationCreateRequest";
 import PollutedLocationResponse from "./types/backEnd/PollutedLocationResponse";
+
+axios.defaults.headers.post["Content-Type"] = "application/json";
 
 export const getAllPollutedLocations = () => {
   return axios.get<PollutedLocationResponse[]>(
     process.env.REACT_APP_BACK_END_URL + "/api/PollutedLocation/All"
+  );
+};
+
+export const createPollutedLocation = (
+  request: PollutedLocationCreateRequest
+) => {
+  return axios.post<PollutedLocationResponse>(
+    process.env.REACT_APP_BACK_END_URL + "/api/PollutedLocation/Create",
+    JSON.stringify(request)
   );
 };

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -5,7 +5,11 @@ type Props = {
 };
 
 const Layout: React.FC<Props> = ({ children }) => {
-  return <div className="flex flex-col md:flex-row h-screen">{children}</div>;
+  return (
+    <div className="absolute inset-0">
+      <div className="flex flex-col md:flex-row h-screen">{children}</div>
+    </div>
+  );
 };
 
 export default Layout;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,11 +1,17 @@
 import React from "react";
+import { use100vh } from "react-div-100vh";
 
 type Props = {
   children: React.ReactNode;
 };
 
 const Layout: React.FC<Props> = ({ children }) => {
-  return <div className="flex flex-col md:flex-row h-screen">{children}</div>;
+  const height = use100vh();
+  return (
+    <div className="flex flex-col md:flex-row" style={{ height: height || 0 }}>
+      {children}
+    </div>
+  );
 };
 
 export default Layout;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -5,11 +5,7 @@ type Props = {
 };
 
 const Layout: React.FC<Props> = ({ children }) => {
-  return (
-    <div className="absolute inset-0">
-      <div className="flex flex-col md:flex-row h-screen">{children}</div>
-    </div>
-  );
+  return <div className="flex flex-col md:flex-row h-screen">{children}</div>;
 };
 
 export default Layout;

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -11,6 +11,11 @@ interface Props {
   showCenterMarker: boolean;
 }
 
+export const vilniusCoordinates: google.maps.LatLngLiteral = {
+  lat: 54.6872,
+  lng: 25.2797,
+};
+
 const Map: React.FC<Props> = ({
   locationsRequest,
   mapRef,

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,14 +1,26 @@
 import { GoogleMap, MarkerF, useLoadScript } from "@react-google-maps/api";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { ApiRequest } from "../../types/backEnd/ApiRequest";
 import PollutedLocation from "../../types/PollutedLocation";
 
 interface Props {
   locationsRequest: ApiRequest<PollutedLocation[]>;
   mapRef: React.MutableRefObject<google.maps.Map | null>;
+  center: google.maps.LatLngLiteral;
+  setCenter: (newCenter: google.maps.LatLngLiteral) => void;
+  showCenterMarker: boolean;
 }
 
-const Map: React.FC<Props> = ({ locationsRequest, mapRef }) => {
+const Map: React.FC<Props> = ({
+  locationsRequest,
+  mapRef,
+  setCenter,
+  center,
+  showCenterMarker,
+}) => {
+  const centerMarkerRef = useRef<google.maps.Marker | null>(null);
+  const [zoom, setZoom] = useState<number>(13);
+
   const markers = useMemo(
     () =>
       locationsRequest.status === "success"
@@ -29,11 +41,6 @@ const Map: React.FC<Props> = ({ locationsRequest, mapRef }) => {
     [locationsRequest]
   );
 
-  const vilniusCoordinates: google.maps.LatLngLiteral = {
-    lat: 54.6872,
-    lng: 25.2797,
-  };
-
   const lithuaniaBounds = {
     north: 56.3725283881,
     south: 53.9057022162,
@@ -44,9 +51,6 @@ const Map: React.FC<Props> = ({ locationsRequest, mapRef }) => {
   const { isLoaded, loadError } = useLoadScript({
     googleMapsApiKey: process.env.REACT_APP_MAPS_API_KEY,
   });
-
-  const [center, setCenter] =
-    useState<google.maps.LatLngLiteral>(vilniusCoordinates);
 
   const handleOnLoad = useCallback((map: google.maps.Map) => {
     mapRef.current = map;
@@ -64,6 +68,16 @@ const Map: React.FC<Props> = ({ locationsRequest, mapRef }) => {
           lat: newCenter.lat(),
           lng: newCenter.lng(),
         });
+        centerMarkerRef?.current?.setPosition(newCenter);
+      }
+    }
+  }, [mapRef]);
+
+  const handleZoomChanged = useCallback(() => {
+    if (mapRef !== null && mapRef.current !== null) {
+      const newZoom = mapRef.current.getZoom();
+      if (newZoom) {
+        setZoom(newZoom);
       }
     }
   }, [mapRef]);
@@ -79,10 +93,15 @@ const Map: React.FC<Props> = ({ locationsRequest, mapRef }) => {
             handleCenterChanged();
           }
         }}
+        onZoomChanged={() => {
+          if (mapRef.current !== null) {
+            handleZoomChanged();
+          }
+        }}
         options={{
           disableDefaultUI: true,
           clickableIcons: false,
-          zoom: 13,
+          zoom: zoom,
           maxZoom: 18,
           center: center,
           restriction: {
@@ -93,9 +112,16 @@ const Map: React.FC<Props> = ({ locationsRequest, mapRef }) => {
         {markers?.map((marker) => (
           <MarkerF position={marker.coordinates} key={marker.id} />
         ))}
+        {showCenterMarker && (
+          <MarkerF
+            position={center}
+            onLoad={(marker) => (centerMarkerRef.current = marker)}
+            onUnmount={() => (centerMarkerRef.current = null)}
+          />
+        )}
       </GoogleMap>
     ),
-    [markers]
+    [markers, showCenterMarker]
   );
 
   if (loadError) return <p>Failed to load map</p>;

--- a/src/components/pollutedLocations/PollutedLocationForm.tsx
+++ b/src/components/pollutedLocations/PollutedLocationForm.tsx
@@ -3,11 +3,13 @@ import usePollutedLocationForm, {
   PollutedLocationFormProps,
 } from "../../hooks/usePollutedLocationForm";
 import { severityLevels } from "../../types/PollutedLocation";
+import PollutedLocationFormResult from "./PollutedLocationFormResult";
 
 const PollutedLocationForm: React.FC<PollutedLocationFormProps> = (props) => {
   const {
     formData,
     request,
+    resetRequest,
     handleSeverityOnChange,
     handleSubmit,
     handleRadiusOnChange,
@@ -16,7 +18,12 @@ const PollutedLocationForm: React.FC<PollutedLocationFormProps> = (props) => {
   } = usePollutedLocationForm(props);
 
   if (request) {
-    return <div>{request.status}</div>;
+    return (
+      <PollutedLocationFormResult
+        request={request}
+        resetRequest={resetRequest}
+      />
+    );
   }
 
   return (

--- a/src/components/pollutedLocations/PollutedLocationForm.tsx
+++ b/src/components/pollutedLocations/PollutedLocationForm.tsx
@@ -1,7 +1,59 @@
 import React from "react";
 
-const PollutedLocationForm: React.FC = () => {
-  return <div>Form placeholder</div>;
+export interface PollutedLocationFormProps {
+  coordinates: google.maps.LatLngLiteral;
+}
+
+const PollutedLocationForm: React.FC<PollutedLocationFormProps> = ({
+  coordinates,
+}) => {
+  return (
+    <div className="flex flex-col justify-between h-full">
+      <div>
+        <h2 className="font-medium text-lg text-center my-5">
+          Report new location
+        </h2>
+        <div className="flex flex-col space-y-5 w-full">
+          <div className="flex flex-row space-x-2">
+            <div className="space-y-1">
+              <label className="block text-sm font-medium text-gray-700">
+                Latitude
+              </label>
+              <input
+                type={"text"}
+                readOnly
+                disabled
+                className="rounded-md border-gray-300 bg-gray-200 shadow-sm text-sm w-full"
+                value={coordinates.lat}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="block text-sm font-medium text-gray-700">
+                Longitude
+              </label>
+              <input
+                type={"text"}
+                readOnly
+                disabled
+                className="rounded-md border-gray-300 bg-gray-200 shadow-sm text-sm w-full"
+                value={coordinates.lng}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="block text-sm font-medium text-gray-700">
+              Notes
+            </label>
+            <textarea className="rounded-md border-gray-300 text-sm min-h-[50px] w-full" />
+          </div>
+        </div>
+      </div>
+      <button className="w-full bg-transparent md:hover:bg-green-500 text-green-700 font-medium md:hover:text-white py-2 px-4 border border-green-500 md:hover:border-transparent rounded">
+        Submit
+      </button>
+    </div>
+  );
 };
 
 export default PollutedLocationForm;

--- a/src/components/pollutedLocations/PollutedLocationForm.tsx
+++ b/src/components/pollutedLocations/PollutedLocationForm.tsx
@@ -1,12 +1,80 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { createPollutedLocation } from "../../backEndClient";
+import { ApiRequest } from "../../types/backEnd/ApiRequest";
+import PollutedLocationCreateRequest from "../../types/backEnd/PollutedLocationCreateRequest";
+import { mapToPollutedLocation } from "../../types/backEnd/PollutedLocationResponse";
+import PollutedLocation from "../../types/PollutedLocation";
 
 export interface PollutedLocationFormProps {
   coordinates: google.maps.LatLngLiteral;
+  setShowCenterMarker: (newValue: boolean) => void;
 }
 
 const PollutedLocationForm: React.FC<PollutedLocationFormProps> = ({
   coordinates,
+  setShowCenterMarker,
 }) => {
+  const [createRequestData, setCreateRequestData] =
+    useState<PollutedLocationCreateRequest>({
+      radius: 1,
+      severity: "low",
+      location: {
+        coordinates: {
+          latitude: coordinates.lat,
+          longitude: coordinates.lng,
+        },
+      },
+    });
+
+  const [request, setRequest] = useState<
+    ApiRequest<PollutedLocation> | undefined
+  >();
+
+  useEffect(() => {
+    setCreateRequestData((previousState) => ({
+      ...previousState,
+      location: {
+        ...previousState.location,
+        coordinates: {
+          latitude: coordinates.lat,
+          longitude: coordinates.lng,
+        },
+      },
+    }));
+  }, [coordinates]);
+
+  useEffect(() => {
+    setShowCenterMarker(true);
+
+    return () => {
+      setShowCenterMarker(false);
+    };
+  }, []);
+
+  const submit = () => {
+    setRequest({
+      status: "loading",
+    });
+    setShowCenterMarker(false);
+
+    createPollutedLocation(createRequestData)
+      .then((response) => {
+        setRequest({
+          status: "success",
+          data: mapToPollutedLocation(response.data),
+        });
+      })
+      .catch(() => {
+        setRequest({
+          status: "error",
+        });
+      });
+  };
+
+  if (request) {
+    return <div>{request.status}</div>;
+  }
+
   return (
     <div className="flex flex-col justify-between h-full">
       <div>
@@ -24,7 +92,7 @@ const PollutedLocationForm: React.FC<PollutedLocationFormProps> = ({
                 readOnly
                 disabled
                 className="rounded-md border-gray-300 bg-gray-200 shadow-sm text-sm w-full"
-                value={coordinates.lat}
+                value={createRequestData.location.coordinates.latitude}
               />
             </div>
             <div className="space-y-1">
@@ -36,7 +104,7 @@ const PollutedLocationForm: React.FC<PollutedLocationFormProps> = ({
                 readOnly
                 disabled
                 className="rounded-md border-gray-300 bg-gray-200 shadow-sm text-sm w-full"
-                value={coordinates.lng}
+                value={createRequestData.location.coordinates.longitude}
               />
             </div>
           </div>
@@ -47,9 +115,23 @@ const PollutedLocationForm: React.FC<PollutedLocationFormProps> = ({
             </label>
             <textarea className="rounded-md border-gray-300 text-sm min-h-[50px] w-full" />
           </div>
+
+          <div>
+            <input
+              type="range"
+              min={0}
+              max={2}
+              defaultValue={0}
+              step={1}
+              className="w-full h-2 bg-gray-300 rounded-md appearance-none cursor-pointer"
+            />
+          </div>
         </div>
       </div>
-      <button className="w-full bg-transparent md:hover:bg-green-500 text-green-700 font-medium md:hover:text-white py-2 px-4 border border-green-500 md:hover:border-transparent rounded">
+      <button
+        onClick={() => submit()}
+        className="w-full bg-transparent md:hover:bg-green-500 text-green-700 font-medium md:hover:text-white py-2 px-4 border border-green-500 md:hover:border-transparent rounded"
+      >
         Submit
       </button>
     </div>

--- a/src/components/pollutedLocations/PollutedLocationForm.tsx
+++ b/src/components/pollutedLocations/PollutedLocationForm.tsx
@@ -6,11 +6,13 @@ import { severityLevels } from "../../types/PollutedLocation";
 
 const PollutedLocationForm: React.FC<PollutedLocationFormProps> = (props) => {
   const {
-    createRequestData,
+    formData,
     request,
     handleSeverityOnChange,
     handleSubmit,
     handleRadiusOnChange,
+    handleNotesOnChange,
+    isFormValid,
   } = usePollutedLocationForm(props);
 
   if (request) {
@@ -34,7 +36,7 @@ const PollutedLocationForm: React.FC<PollutedLocationFormProps> = (props) => {
                 readOnly
                 disabled
                 className="rounded-md border-gray-300 bg-gray-200 shadow-sm text-sm w-full"
-                value={createRequestData.location.coordinates.latitude}
+                value={formData.location.coordinates.latitude}
               />
             </div>
             <div className="space-y-1">
@@ -46,7 +48,7 @@ const PollutedLocationForm: React.FC<PollutedLocationFormProps> = (props) => {
                 readOnly
                 disabled
                 className="rounded-md border-gray-300 bg-gray-200 shadow-sm text-sm w-full"
-                value={createRequestData.location.coordinates.longitude}
+                value={formData.location.coordinates.longitude}
               />
             </div>
           </div>
@@ -58,14 +60,18 @@ const PollutedLocationForm: React.FC<PollutedLocationFormProps> = (props) => {
             <input
               type="number"
               className={`rounded-md ${
-                createRequestData.radius.errors &&
-                createRequestData.radius.errors.length > 0
+                formData.radius.errors.length > 0
                   ? "border-red-600"
                   : "border-gray-300"
               }  shadow-sm text-sm w-full`}
-              value={createRequestData.radius.value}
+              value={formData.radius.value}
               onChange={handleRadiusOnChange}
             />
+            {formData.radius.errors.map((error) => (
+              <p className="mt-2 text-sm text-red-600" key={error}>
+                {error}
+              </p>
+            ))}
           </div>
 
           <div className="space-y-1">
@@ -73,7 +79,7 @@ const PollutedLocationForm: React.FC<PollutedLocationFormProps> = (props) => {
               Severity
             </label>
             <select
-              value={createRequestData.severity}
+              value={formData.severity}
               onChange={handleSeverityOnChange}
               className="rounded-md border-gray-300 w-full"
             >
@@ -93,16 +99,20 @@ const PollutedLocationForm: React.FC<PollutedLocationFormProps> = (props) => {
             <textarea
               className="rounded-md border-gray-300 text-sm min-h-[50px] w-full"
               placeholder="Optional"
-              value={createRequestData.notes}
+              value={formData.notes}
+              onChange={handleNotesOnChange}
             />
           </div>
         </form>
       </div>
       <button
+        disabled={!isFormValid()}
         onClick={() => handleSubmit()}
-        className="w-full bg-transparent md:hover:bg-green-500 text-green-700 font-medium md:hover:text-white py-2 px-4 border border-green-500 md:hover:border-transparent rounded"
+        className="w-full rounded font-medium py-2 px-4 border bg-transparent
+                  enabled:md:hover:bg-green-500 text-green-700 enabled:md:hover:text-white border-green-500 enabled:md:hover:border-transparent
+                  disabled:text-red-700 disabled:border-red-500"
       >
-        Submit
+        {isFormValid() ? "Submit" : "There are errors in the form"}
       </button>
     </div>
   );

--- a/src/components/pollutedLocations/PollutedLocationFormResult.tsx
+++ b/src/components/pollutedLocations/PollutedLocationFormResult.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { MdErrorOutline } from "react-icons/md";
+import { MdCheckCircleOutline } from "react-icons/md";
+import { MdOutlineChangeCircle } from "react-icons/md";
+import { ApiRequest } from "../../types/backEnd/ApiRequest";
+import PollutedLocation from "../../types/PollutedLocation";
+
+interface Props {
+  request: ApiRequest<PollutedLocation>;
+  resetRequest: () => void;
+}
+
+const PollutedLocationFormResult: React.FC<Props> = ({
+  request,
+  resetRequest,
+}) => {
+  const content = () => {
+    switch (request.status) {
+      case "success":
+        return (
+          <div className="flex justify-center items-center h-full">
+            <div className="flex flex-col items-center text-slate-600 text-sm">
+              <div className="text-xl">
+                <MdCheckCircleOutline />
+              </div>
+              <div>Location successfully added!</div>
+            </div>
+          </div>
+        );
+      case "loading":
+        return (
+          <div className="flex justify-center items-center h-full">
+            <div className="flex flex-col items-center text-slate-600 text-sm">
+              <div className="text-2xl animate-spin">
+                <MdOutlineChangeCircle className="transform -scale-x-100" />
+              </div>
+              <div>Loading</div>
+            </div>
+          </div>
+        );
+      case "error":
+      default:
+        return (
+          <div className="flex flex-col justify-between h-full">
+            <div className="grow flex flex-col justify-center items-center text-slate-600 text-sm">
+              <div className="text-xl">
+                <MdErrorOutline />
+              </div>
+              <div>Error</div>
+              <div>Failed to report a new polluted location</div>
+            </div>
+            <button
+              className="w-full bg-transparent md:hover:bg-red-500 text-red-700 font-medium md:hover:text-white py-2 px-4 border border-red-500 md:hover:border-transparent rounded"
+              onClick={() => resetRequest()}
+            >
+              Retry
+            </button>
+          </div>
+        );
+    }
+  };
+
+  return content();
+};
+
+export default PollutedLocationFormResult;

--- a/src/components/sideBar/SideBar.tsx
+++ b/src/components/sideBar/SideBar.tsx
@@ -1,27 +1,34 @@
 import React, { useState } from "react";
-import PollutedLocationForm from "../pollutedLocations/PollutedLocationForm";
+import PollutedLocationForm, {
+  PollutedLocationFormProps,
+} from "../pollutedLocations/PollutedLocationForm";
 import PollutedLocationList, {
   PollutedLocationListProps,
 } from "../pollutedLocations/PollutedLocationList";
 
-const SideBar: React.FC<PollutedLocationListProps> = (
-  pollutedLocationListProps
-) => {
-  const modes = ["list", "form"] as const;
-  const modeComponents: Record<typeof modes[number], React.ReactNode> = {
-    list: <PollutedLocationList {...pollutedLocationListProps} />,
-    form: <PollutedLocationForm />,
-  };
+export const sideBarModes = ["list", "form"] as const;
 
-  const [mode, setMode] = useState<typeof modes[number]>("list");
+interface Props {
+  currentMode: typeof sideBarModes[number];
+  setCurrentMode: (newCurrentMode: typeof sideBarModes[number]) => void;
+}
+
+const SideBar: React.FC<
+  PollutedLocationListProps & PollutedLocationFormProps & Props
+> = (props) => {
+  const modeComponents: Record<typeof sideBarModes[number], React.ReactNode> = {
+    list: <PollutedLocationList {...props} />,
+    form: <PollutedLocationForm {...props} />,
+  };
+  const { currentMode, setCurrentMode } = props;
 
   const controls = () => {
-    switch (mode) {
+    switch (currentMode) {
       case "list":
         return (
           <button
             className="w-full bg-transparent md:hover:bg-green-500 text-green-700 font-medium md:hover:text-white py-2 px-4 border border-green-500 md:hover:border-transparent rounded"
-            onClick={() => setMode("form")}
+            onClick={() => setCurrentMode("form")}
           >
             Report new
           </button>
@@ -30,7 +37,7 @@ const SideBar: React.FC<PollutedLocationListProps> = (
         return (
           <button
             className="w-full bg-transparent md:hover:bg-gray-500 text-gray-700 font-medium md:hover:text-white py-2 px-4 border border-gray-500 md:hover:border-transparent rounded"
-            onClick={() => setMode("list")}
+            onClick={() => setCurrentMode("list")}
           >
             Back to list
           </button>
@@ -41,9 +48,9 @@ const SideBar: React.FC<PollutedLocationListProps> = (
   return (
     <div className="h-2/3 md:h-full flex flex-col flex-1 md:flex-none">
       <div className="w-full md:w-96 flex-1 overflow-y-auto">
-        <div className="m-4">{modeComponents[mode]}</div>
+        <div className="p-4 h-full">{modeComponents[currentMode]}</div>
       </div>
-      <div className="px-4 py-8 flex-none">{controls()}</div>
+      <div className="p-4 flex-none">{controls()}</div>
     </div>
   );
 };

--- a/src/components/sideBar/SideBar.tsx
+++ b/src/components/sideBar/SideBar.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
-import PollutedLocationForm, {
-  PollutedLocationFormProps,
-} from "../pollutedLocations/PollutedLocationForm";
+import { PollutedLocationFormProps } from "../../hooks/usePollutedLocationForm";
+import PollutedLocationForm from "../pollutedLocations/PollutedLocationForm";
 import PollutedLocationList, {
   PollutedLocationListProps,
 } from "../pollutedLocations/PollutedLocationList";

--- a/src/components/sideBar/SideBar.tsx
+++ b/src/components/sideBar/SideBar.tsx
@@ -5,26 +5,24 @@ import PollutedLocationList, {
   PollutedLocationListProps,
 } from "../pollutedLocations/PollutedLocationList";
 
-export const sideBarModes = ["list", "form"] as const;
-
 const SideBar: React.FC<
   PollutedLocationListProps & PollutedLocationFormProps
 > = (props) => {
-  const [currentMode, setCurrentMode] =
-    useState<typeof sideBarModes[number]>("list");
+  const [mode, setMode] = useState<typeof modes[number]>("list");
 
-  const modeComponents: Record<typeof sideBarModes[number], React.ReactNode> = {
+  const modes = ["list", "form"] as const;
+  const modeComponents: Record<typeof modes[number], React.ReactNode> = {
     list: <PollutedLocationList {...props} />,
     form: <PollutedLocationForm {...props} />,
   };
 
   const controls = () => {
-    switch (currentMode) {
+    switch (mode) {
       case "list":
         return (
           <button
             className="w-full bg-transparent md:hover:bg-green-500 text-green-700 font-medium md:hover:text-white py-2 px-4 border border-green-500 md:hover:border-transparent rounded"
-            onClick={() => setCurrentMode("form")}
+            onClick={() => setMode("form")}
           >
             Report new
           </button>
@@ -33,7 +31,7 @@ const SideBar: React.FC<
         return (
           <button
             className="w-full bg-transparent md:hover:bg-gray-500 text-gray-700 font-medium md:hover:text-white py-2 px-4 border border-gray-500 md:hover:border-transparent rounded"
-            onClick={() => setCurrentMode("list")}
+            onClick={() => setMode("list")}
           >
             Back to list
           </button>
@@ -44,7 +42,7 @@ const SideBar: React.FC<
   return (
     <div className="h-2/3 md:h-full flex flex-col flex-1 md:flex-none">
       <div className="w-full md:w-96 flex-1 overflow-y-auto">
-        <div className="p-4 h-full">{modeComponents[currentMode]}</div>
+        <div className="p-4 h-full">{modeComponents[mode]}</div>
       </div>
       <div className="p-4 flex-none">{controls()}</div>
     </div>

--- a/src/components/sideBar/SideBar.tsx
+++ b/src/components/sideBar/SideBar.tsx
@@ -8,19 +8,16 @@ import PollutedLocationList, {
 
 export const sideBarModes = ["list", "form"] as const;
 
-interface Props {
-  currentMode: typeof sideBarModes[number];
-  setCurrentMode: (newCurrentMode: typeof sideBarModes[number]) => void;
-}
-
 const SideBar: React.FC<
-  PollutedLocationListProps & PollutedLocationFormProps & Props
+  PollutedLocationListProps & PollutedLocationFormProps
 > = (props) => {
+  const [currentMode, setCurrentMode] =
+    useState<typeof sideBarModes[number]>("list");
+
   const modeComponents: Record<typeof sideBarModes[number], React.ReactNode> = {
     list: <PollutedLocationList {...props} />,
     form: <PollutedLocationForm {...props} />,
   };
-  const { currentMode, setCurrentMode } = props;
 
   const controls = () => {
     switch (currentMode) {

--- a/src/hooks/usePollutedLocationForm.tsx
+++ b/src/hooks/usePollutedLocationForm.tsx
@@ -13,11 +13,13 @@ import { isInteger, minNumber } from "../utils/validationFunctions";
 export interface PollutedLocationFormProps {
   coordinates: google.maps.LatLngLiteral;
   setShowCenterMarker: (newValue: boolean) => void;
+  addCreatedPollutedLocation: (newLocation: PollutedLocation) => void;
 }
 
 const usePollutedLocationForm = ({
   coordinates,
   setShowCenterMarker,
+  addCreatedPollutedLocation,
 }: PollutedLocationFormProps) => {
   const [formData, setFormData] = useState<PollutedLocationCreateForm>({
     radius: {
@@ -101,9 +103,11 @@ const usePollutedLocationForm = ({
 
     createPollutedLocation(requestData)
       .then((response) => {
+        const createdPollutedLocation = mapToPollutedLocation(response.data);
+        addCreatedPollutedLocation(createdPollutedLocation);
         setRequest({
           status: "success",
-          data: mapToPollutedLocation(response.data),
+          data: createdPollutedLocation,
         });
       })
       .catch(() => {

--- a/src/hooks/usePollutedLocationForm.tsx
+++ b/src/hooks/usePollutedLocationForm.tsx
@@ -47,6 +47,11 @@ const usePollutedLocationForm = ({
     ApiRequest<PollutedLocation> | undefined
   >();
 
+  const resetRequest = () => {
+    setRequest(undefined);
+    setShowCenterMarker(true);
+  };
+
   useEffect(() => {
     setShowCenterMarker(true);
 
@@ -120,6 +125,7 @@ const usePollutedLocationForm = ({
   return {
     formData,
     request,
+    resetRequest,
     handleSeverityOnChange,
     handleRadiusOnChange,
     handleNotesOnChange,

--- a/src/hooks/usePollutedLocationForm.tsx
+++ b/src/hooks/usePollutedLocationForm.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { createPollutedLocation } from "../backEndClient";
+import { ApiRequest } from "../types/backEnd/ApiRequest";
+import PollutedLocationCreateRequest from "../types/backEnd/PollutedLocationCreateRequest";
+import { mapToPollutedLocation } from "../types/backEnd/PollutedLocationResponse";
+import PollutedLocation, { severityLevels } from "../types/PollutedLocation";
+import { isNumber, minNumber } from "../utils/validationFunctions";
+
+export interface PollutedLocationFormProps {
+  coordinates: google.maps.LatLngLiteral;
+  setShowCenterMarker: (newValue: boolean) => void;
+}
+
+const usePollutedLocationForm = ({
+  coordinates,
+  setShowCenterMarker,
+}: PollutedLocationFormProps) => {
+  const [createRequestData, setCreateRequestData] =
+    useState<PollutedLocationCreateRequest>({
+      radius: {
+        value: 5,
+        validationFunctions: [
+          (newValue) => isNumber(newValue),
+          (newValue) => minNumber(newValue, 1),
+        ],
+      },
+      severity: "low",
+      location: {
+        coordinates: {
+          latitude: coordinates.lat,
+          longitude: coordinates.lng,
+        },
+      },
+    });
+
+  const [request, setRequest] = useState<
+    ApiRequest<PollutedLocation> | undefined
+  >();
+
+  useEffect(() => {
+    setShowCenterMarker(true);
+
+    return () => {
+      setShowCenterMarker(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    setCreateRequestData((previousState) => ({
+      ...previousState,
+      location: {
+        ...previousState.location,
+        coordinates: {
+          latitude: coordinates.lat,
+          longitude: coordinates.lng,
+        },
+      },
+    }));
+  }, [coordinates]);
+
+  const handleSeverityOnChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newValue = severityLevels.find((l) => l === e.target.value);
+
+    if (!newValue) return;
+
+    setCreateRequestData((previousState) => ({
+      ...previousState,
+      severity: newValue,
+    }));
+  };
+
+  const handleRadiusOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = +e.target.value;
+
+    const errors: string[] = [];
+    createRequestData.radius.validationFunctions.forEach((validation) => {
+      const error = validation(newValue);
+      if (error !== undefined) errors.push(error);
+    });
+
+    setCreateRequestData((previousState) => ({
+      ...previousState,
+      radius: {
+        ...previousState.radius,
+        value: newValue,
+        errors: errors,
+      },
+    }));
+  };
+
+  const handleSubmit = () => {
+    setRequest({
+      status: "loading",
+    });
+    setShowCenterMarker(false);
+
+    createPollutedLocation(createRequestData)
+      .then((response) => {
+        setRequest({
+          status: "success",
+          data: mapToPollutedLocation(response.data),
+        });
+      })
+      .catch(() => {
+        setRequest({
+          status: "error",
+        });
+      });
+  };
+
+  return {
+    createRequestData,
+    request,
+    handleSeverityOnChange,
+    handleRadiusOnChange,
+    handleSubmit,
+  };
+};
+
+export default usePollutedLocationForm;

--- a/src/hooks/usePollutedLocationForm.tsx
+++ b/src/hooks/usePollutedLocationForm.tsx
@@ -27,7 +27,7 @@ const usePollutedLocationForm = ({
       errors: [],
       validationFunctions: [
         (newValue) => isInteger(newValue),
-        (newValue) => minNumber(newValue, 1),
+        (newValue) => (newValue ? minNumber(newValue, 1) : undefined),
       ],
     },
     severity: "low",
@@ -87,7 +87,10 @@ const usePollutedLocationForm = ({
   const handleRadiusOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData((previousState) => ({
       ...previousState,
-      radius: validate(formData.radius, +e.target.value),
+      radius: validate(
+        formData.radius,
+        e.target.value === "" ? undefined : +e.target.value
+      ),
     }));
   };
 

--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,9 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+@supports (-webkit-touch-callout: none) {
+  .h-screen {
+    height: -webkit-fill-available;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -15,9 +15,3 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
-
-@supports (-webkit-touch-callout: none) {
-  .h-screen {
-    height: -webkit-fill-available;
-  }
-}

--- a/src/types/Validated.ts
+++ b/src/types/Validated.ts
@@ -1,7 +1,21 @@
 type Validated<T> = {
   value: T;
-  errors?: string[];
+  errors: string[];
   validationFunctions: ((newValue: T) => string | undefined)[];
+};
+
+export const validate = <T>(field: Validated<T>, newValue: T) => {
+  const errors: string[] = [];
+  field.validationFunctions.forEach((validation) => {
+    const error = validation(newValue);
+    if (error !== undefined) errors.push(error);
+  });
+
+  return {
+    ...field,
+    value: newValue,
+    errors,
+  };
 };
 
 export default Validated;

--- a/src/types/Validated.ts
+++ b/src/types/Validated.ts
@@ -1,0 +1,7 @@
+type Validated<T> = {
+  value: T;
+  errors?: string[];
+  validationFunctions: ((newValue: T) => string | undefined)[];
+};
+
+export default Validated;

--- a/src/types/backEnd/PollutedLocationCreateRequest.ts
+++ b/src/types/backEnd/PollutedLocationCreateRequest.ts
@@ -1,0 +1,15 @@
+import { severityLevels } from "../PollutedLocation";
+
+type PollutedLocationCreateRequest = {
+  location: {
+    coordinates: {
+      longitude: number;
+      latitude: number;
+    };
+  };
+  radius: number;
+  severity: typeof severityLevels[number];
+  notes?: string;
+};
+
+export default PollutedLocationCreateRequest;

--- a/src/types/backEnd/PollutedLocationCreateRequest.ts
+++ b/src/types/backEnd/PollutedLocationCreateRequest.ts
@@ -1,4 +1,5 @@
 import { severityLevels } from "../PollutedLocation";
+import Validated from "../Validated";
 
 type PollutedLocationCreateRequest = {
   location: {
@@ -7,7 +8,7 @@ type PollutedLocationCreateRequest = {
       latitude: number;
     };
   };
-  radius: number;
+  radius: Validated<number>;
   severity: typeof severityLevels[number];
   notes?: string;
 };

--- a/src/types/backEnd/PollutedLocationCreateRequest.ts
+++ b/src/types/backEnd/PollutedLocationCreateRequest.ts
@@ -8,7 +8,7 @@ export type PollutedLocationCreateForm = {
       latitude: number;
     };
   };
-  radius: Validated<number>;
+  radius: Validated<number | undefined>;
   severity: typeof severityLevels[number];
   notes?: string;
 };
@@ -30,7 +30,7 @@ export const toPollutedLocationCreateRequest: (
 ) => PollutedLocationCreateRequest = (form) => {
   return {
     ...form,
-    radius: form.radius.value,
+    radius: form.radius.value || 1,
   };
 };
 

--- a/src/types/backEnd/PollutedLocationCreateRequest.ts
+++ b/src/types/backEnd/PollutedLocationCreateRequest.ts
@@ -1,7 +1,7 @@
 import { severityLevels } from "../PollutedLocation";
 import Validated from "../Validated";
 
-type PollutedLocationCreateRequest = {
+export type PollutedLocationCreateForm = {
   location: {
     coordinates: {
       longitude: number;
@@ -11,6 +11,27 @@ type PollutedLocationCreateRequest = {
   radius: Validated<number>;
   severity: typeof severityLevels[number];
   notes?: string;
+};
+
+type PollutedLocationCreateRequest = {
+  location: {
+    coordinates: {
+      longitude: number;
+      latitude: number;
+    };
+  };
+  radius: number;
+  severity: typeof severityLevels[number];
+  notes?: string;
+};
+
+export const toPollutedLocationCreateRequest: (
+  form: PollutedLocationCreateForm
+) => PollutedLocationCreateRequest = (form) => {
+  return {
+    ...form,
+    radius: form.radius.value,
+  };
 };
 
 export default PollutedLocationCreateRequest;

--- a/src/utils/validationFunctions.ts
+++ b/src/utils/validationFunctions.ts
@@ -11,4 +11,8 @@ const isNumber: (newValue: number) => string | undefined = (newValue) => {
   return !isNaN(newValue) ? undefined : `Value must be a number`;
 };
 
-export { minNumber, isNumber };
+const isInteger: (newValue: number) => string | undefined = (newValue) => {
+  return Number.isInteger(newValue) ? undefined : `Value must be an integer`;
+};
+
+export { minNumber, isNumber, isInteger };

--- a/src/utils/validationFunctions.ts
+++ b/src/utils/validationFunctions.ts
@@ -1,0 +1,14 @@
+const minNumber: (newValue: number, minValue: number) => string | undefined = (
+  newValue,
+  minValue
+) => {
+  return newValue >= minValue
+    ? undefined
+    : `Value must be higher or equal to ${minValue}`;
+};
+
+const isNumber: (newValue: number) => string | undefined = (newValue) => {
+  return !isNaN(newValue) ? undefined : `Value must be a number`;
+};
+
+export { minNumber, isNumber };

--- a/src/utils/validationFunctions.ts
+++ b/src/utils/validationFunctions.ts
@@ -7,12 +7,18 @@ const minNumber: (newValue: number, minValue: number) => string | undefined = (
     : `Value must be higher or equal to ${minValue}`;
 };
 
-const isNumber: (newValue: number) => string | undefined = (newValue) => {
-  return !isNaN(newValue) ? undefined : `Value must be a number`;
+const isNumber: (newValue: number | undefined) => string | undefined = (
+  newValue
+) => {
+  return newValue && !isNaN(newValue) ? undefined : `Value must be a number`;
 };
 
-const isInteger: (newValue: number) => string | undefined = (newValue) => {
-  return Number.isInteger(newValue) ? undefined : `Value must be an integer`;
+const isInteger: (newValue: number | undefined) => string | undefined = (
+  newValue
+) => {
+  return newValue && Number.isInteger(newValue)
+    ? undefined
+    : `Value must be an integer`;
 };
 
 export { minNumber, isNumber, isInteger };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    "./src/**/*.{js,jsx,ts,tsx}",
-  ],
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {},
   },
-  plugins: [],
-}
+  plugins: [require("@tailwindcss/forms")],
+};


### PR DESCRIPTION
## What was done

Implemented a form that sends an HTTP POST to our `/api/PollutedLocation/Create` endpoint

- Add `PollutedLocationCreateRequest`, `PollutedLocationCreateForm` types
- Validation (reusable, modular)
- Response handling (loading, success, error)
- The created polluted location is added to the list/map *without requerying* all of the existing locations
- State changes. Had to move some of the state to `App.tsx` for it to be shared between the form and the map
- Seems to look fine on mobile

Some form sidebar states:
![form-states-apsitvarkom-fe](https://user-images.githubusercontent.com/29711974/204113114-8aeb027c-c7dc-43dd-b4c8-9ffde9e09954.png)

Requires https://github.com/vu-vibedosa/apsitvarkom-be/pull/118
Closes #40 