### PR TITLE
PollutedLocation type title adjustments for internationalization

### DIFF
--- a/src/components/pollutedLocations/PollutedLocationCard.tsx
+++ b/src/components/pollutedLocations/PollutedLocationCard.tsx
@@ -4,9 +4,10 @@ import { MdDeleteOutline } from "react-icons/md";
 import { MdOutlineRadar } from "react-icons/md";
 import PollutedLocation, { severityLevels } from "../../types/PollutedLocation";
 import { useTranslation } from "react-i18next";
+import i18next from "i18next";
+import supportedLanguages from "../../languages";
 
 const defaultIconSize = 35;
-const { t } = useTranslation();
 
 interface Props {
   pollutedLocation: PollutedLocation;
@@ -17,18 +18,23 @@ const PollutedLocationCard: React.FC<Props> = ({
   pollutedLocation,
   googleMap,
 }) => {
+  const { t } = useTranslation();
   const { location, radius, progress, severity } = pollutedLocation;
 
   const filledTrashIcons: number =
     (severityLevels.findIndex((x) => x === severity) || 0) + 1;
 
   const emptyTrashIcons: number = severityLevels.length - filledTrashIcons;
+  const currentLanguage =
+    supportedLanguages.find((x) => x === i18next.language) ||
+    supportedLanguages[0];
 
   return (
     <CardLayout
       title={
         <h2 className="text-lg">
-          {location?.title || t("titleMissing", "Title is missing")}
+          {location?.title?.[currentLanguage] ||
+            t("titleMissing", "Title is missing")}
         </h2>
       }
       progressText={<p className="text-sm text-blue-700">{progress || 0}%</p>}

--- a/src/components/pollutedLocations/PollutedLocationCard.tsx
+++ b/src/components/pollutedLocations/PollutedLocationCard.tsx
@@ -3,8 +3,10 @@ import { MdDelete } from "react-icons/md";
 import { MdDeleteOutline } from "react-icons/md";
 import { MdOutlineRadar } from "react-icons/md";
 import PollutedLocation, { severityLevels } from "../../types/PollutedLocation";
+import { useTranslation } from "react-i18next";
 
 const defaultIconSize = 35;
+const { t } = useTranslation();
 
 interface Props {
   pollutedLocation: PollutedLocation;
@@ -25,7 +27,9 @@ const PollutedLocationCard: React.FC<Props> = ({
   return (
     <CardLayout
       title={
-        <h2 className="text-lg">{location?.title || "Title is missing"}</h2>
+        <h2 className="text-lg">
+          {location?.title || t("titleMissing", "Title is missing")}
+        </h2>
       }
       progressText={<p className="text-sm text-blue-700">{progress || 0}%</p>}
       progressBar={

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -20,6 +20,7 @@
   "severityHigh": "High",
   "severityLow": "Low",
   "severityModerate": "Moderate",
+  "titleMissing": "Title is missing",
   "validationIsInteger": "Value must be an integer",
   "validationIsNumber": "Value must be a number",
   "validationIsRequired": "Value is required",

--- a/src/locale/lt.json
+++ b/src/locale/lt.json
@@ -20,6 +20,7 @@
   "severityHigh": "Aukštas",
   "severityLow": "Žemas",
   "severityModerate": "Vidutinis",
+  "titleMissing": "Nežinoma vieta",
   "validationIsInteger": "Reikšmė turi būti sveikasis skaičius",
   "validationIsNumber": "Reikšmė turi būti skaičius",
   "validationIsRequired": "Reikšmė privaloma",

--- a/src/types/PollutedLocation.ts
+++ b/src/types/PollutedLocation.ts
@@ -19,7 +19,10 @@ export const severityLevelsLocalized = (t: TFunction) => {
 type PollutedLocation = Partial<{
   id: string;
   location: Partial<{
-    title: string;
+    title: Partial<{
+      en: string;
+      lt: string;
+    }>;
     coordinates: Partial<{
       longitude: number;
       latitude: number;

--- a/src/types/PollutedLocation.ts
+++ b/src/types/PollutedLocation.ts
@@ -1,4 +1,5 @@
 import { DefaultTFuncReturn, TFunction } from "i18next";
+import supportedLanguages from "../languages";
 import CleaningEvent from "./CleaningEvent";
 
 export const severityLevels = ["low", "moderate", "high"] as const;
@@ -19,10 +20,7 @@ export const severityLevelsLocalized = (t: TFunction) => {
 type PollutedLocation = Partial<{
   id: string;
   location: Partial<{
-    title: Partial<{
-      en: string;
-      lt: string;
-    }>;
+    title: Record<typeof supportedLanguages[number], string>;
     coordinates: Partial<{
       longitude: number;
       latitude: number;

--- a/src/types/backEnd/PollutedLocationResponse.ts
+++ b/src/types/backEnd/PollutedLocationResponse.ts
@@ -6,7 +6,10 @@ import CleaningEventResponse, {
 type PollutedLocationResponse = Partial<{
   id: string;
   location: Partial<{
-    title: string;
+    title: Partial<{
+      en: string;
+      lt: string;
+    }>;
     coordinates: Partial<{
       longitude: number;
       latitude: number;

--- a/src/types/backEnd/PollutedLocationResponse.ts
+++ b/src/types/backEnd/PollutedLocationResponse.ts
@@ -1,3 +1,4 @@
+import supportedLanguages from "../../languages";
 import PollutedLocation, { severityLevels } from "../PollutedLocation";
 import CleaningEventResponse, {
   mapToCleaningEvent,
@@ -6,10 +7,7 @@ import CleaningEventResponse, {
 type PollutedLocationResponse = Partial<{
   id: string;
   location: Partial<{
-    title: Partial<{
-      en: string;
-      lt: string;
-    }>;
+    title: Record<typeof supportedLanguages[number], string>;
     coordinates: Partial<{
       longitude: number;
       latitude: number;


### PR DESCRIPTION
## What was done

- PollutedLocation and PollutedLocationResponse types got updated title to match [#122](https://github.com/vu-vibedosa/apsitvarkom-be/pull/122)
- Translated `Title is missing` message
